### PR TITLE
Allow to provide protocol in gravatar service url

### DIFF
--- a/src/main/java/com/googlesource/gerrit/plugins/avatars/gravatar/GravatarAvatarProvider.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/avatars/gravatar/GravatarAvatarProvider.java
@@ -54,10 +54,17 @@ public class GravatarAvatarProvider implements AvatarProvider {
     ssl = canonicalUrl.startsWith("https://");
     this.avatarType = cfgFactory.getFromGerritConfig(pluginName)
                                 .getString("type", "identicon");
-    this.gravatarUrl = cfgFactory.getFromGerritConfig(pluginName)
+    String gravatarUrl = cfgFactory.getFromGerritConfig(pluginName)
                                  .getString("gravatarUrl", "www.gravatar.com/avatar/");
     this.changeAvatarUrl = cfgFactory.getFromGerritConfig(pluginName)
                                .getString("changeAvatarUrl", "http://www.gravatar.com");
+
+    if (gravatarUrl.matches("^https?://.+"))
+      this.gravatarUrl = gravatarUrl;
+    else if (ssl)
+      this.gravatarUrl = "https://" + gravatarUrl;
+    else
+      this.gravatarUrl = "http://" + gravatarUrl;
   }
 
   @Override
@@ -77,13 +84,7 @@ public class GravatarAvatarProvider implements AvatarProvider {
       throw new RuntimeException(
           "MD5 digest not supported - required for Gravatar");
     }
-    StringBuilder url = new StringBuilder();
-    if (ssl) {
-      url.append("https://");
-    } else {
-      url.append("http://");
-    }
-    url.append(gravatarUrl);
+    StringBuilder url = new StringBuilder(gravatarUrl);
     url.append(hex(emailMd5));
     url.append(".jpg");
     // TODO: currently we force the default icon to identicon and the rating

--- a/src/main/resources/Documentation/config.md
+++ b/src/main/resources/Documentation/config.md
@@ -22,7 +22,7 @@ file.
 `plugin.@PLUGIN@.gravatarUrl`
 :	URL that provides the Gravatar API.
 
-	Uses the same protocol (http, https) as gerrit.canonicalWebUrl.
+	Uses provided protocol (http, https) or the same as gerrit.canonicalWebUrl.
 
 	Default: www.gravatar.com/avatar/
 


### PR DESCRIPTION
Gravatar service protocol (http, https) can be included in provided url. 
If the protocol is not present, it will be taken from canonical web url (backward compatibility will be maintained).

The reason we needed to make this change was because the plugin was breaking our SSL by generating unsecure content warning (gravatars served over HTTP). Our gerrit service is served via HTTP but users access it thru a reverse proxy that serves it over HTTPS. Eventually, gerrit access is provided via HTTPS but gravatars are provided via HTTP (canonical url is set to HTTP).
